### PR TITLE
Exclude AWS-dependent tests from CI

### DIFF
--- a/microcosm_dynamodb/tests/test_example.py
+++ b/microcosm_dynamodb/tests/test_example.py
@@ -10,6 +10,7 @@ from hamcrest import (
     is_,
     raises,
 )
+from nose.plugins.attrib import attr
 
 from microcosm.api import create_object_graph
 from microcosm_dynamodb.errors import (
@@ -19,6 +20,7 @@ from microcosm_dynamodb.example import Company
 from microcosm_dynamodb.operations import recreate_all
 
 
+@attr('aws')
 class TestCompany(object):
 
     def setup(self):

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27, lint
 
 [testenv]
 commands =
-    python setup.py nosetests --with-coverage --cover-package=microcosm_dynamodb --cover-erase --cover-html
+    python setup.py nosetests --with-coverage --cover-package=microcosm_dynamodb --cover-erase --cover-html -a !aws
     python setup.py sdist
 deps =
     setuptools>=17.1


### PR DESCRIPTION
This enables running through CI / deploying package to PyPI successfully.
For enabling these in CI we will need to either support a dummy AWS account that
we can use for this, or otherwise have more extensive mocking capabilities.

- add 'aws' attribute tag to the AWS-dependent unit-test suite
- exclude 'aws'-tagged tests from running via tox by default