### PR TITLE
support flywheel namespaces (table prefixes)

### DIFF
--- a/microcosm_dynamodb/factories.py
+++ b/microcosm_dynamodb/factories.py
@@ -10,6 +10,7 @@ from microcosm.api import defaults
 
 
 @defaults(
+    namespace=None,
     region=environ.get("AWS_DEFAULT_REGION"),
 )
 def configure_flywheel_engine(graph):
@@ -17,7 +18,7 @@ def configure_flywheel_engine(graph):
     Create the flywheel engine.
 
     """
-    namespace = ()
+    namespace = graph.config.dynamodb.namespace or ()
     if graph.metadata.testing:
         namespace = "test"
 

--- a/microcosm_dynamodb/factories.py
+++ b/microcosm_dynamodb/factories.py
@@ -10,7 +10,7 @@ from microcosm.api import defaults
 
 
 @defaults(
-    namespace=None,
+    namespace='',
     region=environ.get("AWS_DEFAULT_REGION"),
 )
 def configure_flywheel_engine(graph):
@@ -18,9 +18,9 @@ def configure_flywheel_engine(graph):
     Create the flywheel engine.
 
     """
-    namespace = graph.config.dynamodb.namespace or ()
+    namespace = graph.config.dynamodb.namespace
     if graph.metadata.testing:
-        namespace = "test"
+        namespace = "test:"
 
     engine = Engine(namespace=namespace)
     engine.connect_to_region(graph.config.dynamodb.region)

--- a/microcosm_dynamodb/factories.py
+++ b/microcosm_dynamodb/factories.py
@@ -20,7 +20,7 @@ def configure_flywheel_engine(graph):
     """
     namespace = graph.config.dynamodb.namespace
     if graph.metadata.testing:
-        namespace = "test:"
+        namespace = "test-"
 
     engine = Engine(namespace=namespace)
     engine.connect_to_region(graph.config.dynamodb.region)


### PR DESCRIPTION
This PR enables us to adhere to our multiple-environments-per-account AWS architecture whereby we might have multiple instances of a single logical dynamodb table on a single AWS account belonging to different logical 'environments'.

See https://globality.atlassian.net/browse/GLOB-2867 for more details