### PR TITLE
Support additional criteria in store.delete to support (hash_key, sort_key) type models

### DIFF
--- a/microcosm_dynamodb/store.py
+++ b/microcosm_dynamodb/store.py
@@ -110,14 +110,17 @@ class Store(object):
         except ModelNotFoundError:
             return self.create(new_instance)
 
-    def delete(self, identifier):
+    def delete(self, identifier, *criterion):
         """
-        Delete a model by primary key.
+        Delete a model by primary key and optional additional criteria.
 
         :raises `ModelNotFoundError` if the row cannot be deleted.
 
         """
-        return self._delete(self.model_class.id == identifier)
+        return self._delete(
+            self.model_class.id == identifier,
+            *criterion
+        )
 
     def count(self, *criterion, **kwargs):
         """


### PR DESCRIPTION
This PR makes Store.delete() behave more like our default Store.retrieve() in allowing optional additional criteria.
This is needed in DynamoDB land where tables which employ both a hash_key and a sort_key always require both for
look up on a specific row.