### PR TITLE
Encrypted dynamodb configuration loader

### DIFF
--- a/microcosm_dynamodb/loaders.py
+++ b/microcosm_dynamodb/loaders.py
@@ -1,0 +1,159 @@
+"""
+Microcosm compatible configuration loader.
+
+"""
+from collections import namedtuple
+
+from boto3 import client, Session
+from boto3.dynamodb.conditions import Key
+
+
+TableDefinition = namedtuple("TableDefinition", ["name", "read_capacity", "write_capacity"])
+
+
+DEFAULT_TABLE_DEFINITION = TableDefinition(
+    name="config",
+    read_capacity=1,
+    write_capacity=1,
+)
+
+
+ConfigKey = "ConfigKey"
+ConfigValue = "ConfigValue"
+ServiceName = "ServiceName"
+
+
+class DynamoDBLoader(object):
+    """
+    Load config data from a DynamoDB table containing `ServiceName`, `ConfigKey`, `ConfigValue` tuples.
+
+    Only configuration for the current service name (via `metadata.name`) are loaded.
+
+    Configuration keys will be split into nested dictionaries based on the current separator.
+
+    """
+    def __init__(self, table_definition=DEFAULT_TABLE_DEFINITION, separator=".", profile_name=None, region=None):
+        self.table_definition = table_definition
+        self.separator = separator
+        self.profile_name = profile_name
+        self.region = region
+
+    @property
+    def table(self):
+        session = Session(profile_name=self.profile_name)
+        dynamodb = session.resource('dynamodb', region_name=self.region)
+        return dynamodb.Table(self.table_definition.name)
+
+    def create_table(self):
+        """
+        Create a table with a primary key (the service name) and a sort key (the config key name).
+
+        Under normal circumstances this table should be created out-of-band with an automated tool
+        (such as Terraform or CloudFormation) and along with appropriate access controls.
+
+        """
+        dynamodb_client = client("dynamodb")
+        dynamodb_client.create_table(
+            TableName=self.table_definition.name,
+            AttributeDefinitions=[
+                {
+                    "AttributeName": ServiceName,
+                    "AttributeType": "S",
+                },
+                {
+                    "AttributeName": ConfigKey,
+                    "AttributeType": "S",
+                },
+            ],
+            KeySchema=[
+                {
+                    "AttributeName": ServiceName,
+                    "KeyType": "HASH",
+                },
+                {
+                    "AttributeName": ConfigKey,
+                    "KeyType": "RANGE",
+                }
+            ],
+            ProvisionedThroughput={
+                "ReadCapacityUnits": self.table_definition.read_capacity,
+                "WriteCapacityUnits": self.table_definition.write_capacity,
+            }
+        )
+
+    def all(self, service):
+        """
+        Query all service config rows.
+
+        """
+        return self.table.query(
+            Select="SPECIFIC_ATTRIBUTES",
+            ProjectionExpression=", ".join([ConfigKey, ConfigValue]),
+            ConsistentRead=True,
+            KeyConditionExpression=Key(ServiceName).eq(service),
+        )
+
+    def items(self, service):
+        """
+        Generate configuration key rows as items.
+
+        """
+        return [
+            (row[ConfigKey], row[ConfigValue])
+            for row in self.all(service)["Items"]
+        ]
+
+    def put(self, service, key, value):
+        """
+        Put a configuration value.
+
+        """
+        self.table.put_item(
+            Item={
+                ServiceName: service,
+                ConfigKey: key,
+                ConfigValue: value,
+            },
+        )
+
+    def get(self, service, key):
+        """
+        Get a configuration value.
+
+        """
+        result = self.table.get_item(
+            Key={
+                ServiceName: service,
+                ConfigKey: key,
+            },
+        )
+        return result.get("Item")
+
+    def delete(self, service, key):
+        """
+        Delete a configuration value.
+
+        """
+        result = self.table.delete_item(
+            Key={
+                ServiceName: service,
+                ConfigKey: key,
+            },
+        )
+        return result
+
+    def __call__(self, metadata):
+        """
+        Build configuration.
+
+        """
+        config = {}
+        for key, value in self.items(metadata.name):
+            # expand key into nested dictionaries
+            key_parts = key.split(self.separator)
+            config_part = config
+            for key_part in key_parts[:-1]:
+                config_part = config.setdefault(key_part, {})
+            # save value
+            config_part[key_parts[-1]] = value
+        return config

--- a/microcosm_dynamodb/loaders.py
+++ b/microcosm_dynamodb/loaders.py
@@ -2,13 +2,20 @@
 Microcosm compatible configuration loader.
 
 """
+from base64 import b64decode, b64encode
 from collections import namedtuple
 
 from boto3 import client, Session
 from boto3.dynamodb.conditions import Key
+from Crypto.Cipher import AES
+from Crypto.Hash import SHA256
+from Crypto.Hash.HMAC import HMAC
+from Crypto.Util import Counter
 
 
 TableDefinition = namedtuple("TableDefinition", ["name", "read_capacity", "write_capacity"])
+PlaintextValue = namedtuple("PlaintextValue", ["plaintext"])
+EncryptedValue = namedtuple("EncryptedValue", ["cyphertext_key", "cyphertext", "cyphertext_hmac"])
 
 
 DEFAULT_TABLE_DEFINITION = TableDefinition(
@@ -18,14 +25,17 @@ DEFAULT_TABLE_DEFINITION = TableDefinition(
 )
 
 
-ConfigKey = "ConfigKey"
-ConfigValue = "ConfigValue"
-ServiceName = "ServiceName"
+CONFIG_NAME = "config_name"
+SERVICE_NAME = "service_service"
 
 
 class DynamoDBLoader(object):
     """
-    Load config data from a DynamoDB table containing `ServiceName`, `ConfigKey`, `ConfigValue` tuples.
+    Load config data from a DynamoDB table.
+
+    Usage:
+        loader.put("test", "foo", PlaintextValue("bar"))
+        print loader.get("test", "foo").plaintext
 
     Only configuration for the current service name (via `metadata.name`) are loaded.
 
@@ -37,6 +47,24 @@ class DynamoDBLoader(object):
         self.separator = separator
         self.profile_name = profile_name
         self.region = region
+
+    @property
+    def value_type(self):
+        """
+        Return the value type to use.
+
+        The value type is polymorphic and should be a namedtuple with no keys overlapping the
+        the dynamodb table's index and sort keys.
+
+        """
+        return PlaintextValue
+
+    def get_plaintext(self, value):
+        """
+        Get a plaintext value from the value type.
+
+        """
+        return value.plaintext
 
     @property
     def table(self):
@@ -57,21 +85,21 @@ class DynamoDBLoader(object):
             TableName=self.table_definition.name,
             AttributeDefinitions=[
                 {
-                    "AttributeName": ServiceName,
+                    "AttributeName": SERVICE_NAME,
                     "AttributeType": "S",
                 },
                 {
-                    "AttributeName": ConfigKey,
+                    "AttributeName": CONFIG_NAME,
                     "AttributeType": "S",
                 },
             ],
             KeySchema=[
                 {
-                    "AttributeName": ServiceName,
+                    "AttributeName": SERVICE_NAME,
                     "KeyType": "HASH",
                 },
                 {
-                    "AttributeName": ConfigKey,
+                    "AttributeName": CONFIG_NAME,
                     "KeyType": "RANGE",
                 }
             ],
@@ -88,9 +116,9 @@ class DynamoDBLoader(object):
         """
         return self.table.query(
             Select="SPECIFIC_ATTRIBUTES",
-            ProjectionExpression=", ".join([ConfigKey, ConfigValue]),
+            ProjectionExpression=", ".join([CONFIG_NAME] + list(self.value_type._fields)),
             ConsistentRead=True,
-            KeyConditionExpression=Key(ServiceName).eq(service),
+            KeyConditionExpression=Key(SERVICE_NAME).eq(service),
         )
 
     def items(self, service):
@@ -99,45 +127,63 @@ class DynamoDBLoader(object):
 
         """
         return [
-            (row[ConfigKey], row[ConfigValue])
+            (row[CONFIG_NAME], self.get_plaintext(self.value_type(**{
+                name: value
+                for name, value in row.items()
+                if name != CONFIG_NAME
+            })))
             for row in self.all(service)["Items"]
         ]
 
-    def put(self, service, key, value):
+    def put(self, service, name, value):
         """
         Put a configuration value.
 
         """
+        if not isinstance(value, self.value_type):
+            raise Exception("Expected value to be an instance of: {}".format(
+                self.value_type.__name__,
+            ))
+        item = {
+            SERVICE_NAME: service,
+            CONFIG_NAME: name,
+        }
+        item.update(vars(value))
         self.table.put_item(
-            Item={
-                ServiceName: service,
-                ConfigKey: key,
-                ConfigValue: value,
-            },
+            Item=item,
         )
 
-    def get(self, service, key):
+    def get(self, service, name):
         """
         Get a configuration value.
 
         """
         result = self.table.get_item(
             Key={
-                ServiceName: service,
-                ConfigKey: key,
+                SERVICE_NAME: service,
+                CONFIG_NAME: name,
             },
         )
-        return result.get("Item")
 
-    def delete(self, service, key):
+        item = result.get("Item")
+        if item is None:
+            return None
+
+        return self.value_type(**{
+            key: value
+            for key, value in item.items()
+            if key not in (SERVICE_NAME, CONFIG_NAME)
+        })
+
+    def delete(self, service, name):
         """
         Delete a configuration value.
 
         """
         result = self.table.delete_item(
             Key={
-                ServiceName: service,
-                ConfigKey: key,
+                SERVICE_NAME: service,
+                CONFIG_NAME: name,
             },
         )
         return result
@@ -148,12 +194,90 @@ class DynamoDBLoader(object):
 
         """
         config = {}
-        for key, value in self.items(metadata.name):
-            # expand key into nested dictionaries
-            key_parts = key.split(self.separator)
+        for name, value in self.items(metadata.name):
+            # expand name into nested dictionaries
+            name_parts = name.split(self.separator)
             config_part = config
-            for key_part in key_parts[:-1]:
-                config_part = config.setdefault(key_part, {})
+            for name_part in name_parts[:-1]:
+                config_part = config.setdefault(name_part, {})
             # save value
-            config_part[key_parts[-1]] = value
+            config_part[name_parts[-1]] = value
         return config
+
+
+class EncryptedDynamoDBLoader(DynamoDBLoader):
+    """
+    Encrypt configuration using KMS.
+
+    Usage:
+        loader.put("test", "foo", loader.encrypt("bar"))
+        print loader.decrypt(loader.get("test", "foo"))
+
+    Code adapted with much appreciation to credstash. See:
+
+    https://github.com/fugue/credstash/blob/master/credstash.py
+
+    """
+    def __init__(self, kms_key, **kwargs):
+        super(EncryptedDynamoDBLoader, self).__init__(**kwargs)
+        self.kms_key = kms_key
+
+    @property
+    def value_type(self):
+        return EncryptedValue
+
+    def get_plaintext(self, value):
+        return self.decrypt(value)
+
+    def encrypt(self, plaintext, context=None):
+        if not context:
+            context = {}
+
+        session = Session(profile_name=self.profile_name)
+        kms = session.client('kms', region_name=self.region)
+        kms_response = kms.generate_data_key(
+            KeyId=self.kms_key,
+            EncryptionContext=context,
+            NumberOfBytes=64,
+        )
+        data_key = kms_response['Plaintext'][:32]
+        hmac_key = kms_response['Plaintext'][32:]
+        wrapped_key = kms_response['CiphertextBlob']
+        enc_ctr = Counter.new(128)
+        encryptor = AES.new(data_key, AES.MODE_CTR, counter=enc_ctr)
+        c_text = encryptor.encrypt(plaintext)
+        # compute an HMAC using the hmac key and the ciphertext
+        hmac = HMAC(hmac_key, msg=c_text, digestmod=SHA256)
+        b64hmac = hmac.hexdigest()
+
+        return EncryptedValue(
+            b64encode(wrapped_key).decode('utf-8'),
+            b64encode(c_text).decode('utf-8'),
+            b64hmac,
+        )
+
+    def decrypt(self, value, context=None):
+        if not context:
+            context = {}
+
+        session = Session(profile_name=self.profile_name)
+        kms = session.client('kms', region_name=self.region)
+
+        # Check the HMAC before we decrypt to verify ciphertext integrity
+        kms_response = kms.decrypt(
+            CiphertextBlob=b64decode(value.cyphertext_key),
+            EncryptionContext=context,
+        )
+        key = kms_response['Plaintext'][:32]
+        hmac_key = kms_response['Plaintext'][32:]
+        hmac = HMAC(
+            hmac_key,
+            msg=b64decode(value.cyphertext),
+            digestmod=SHA256,
+        )
+        if hmac.hexdigest() != value.cyphertext_hmac:
+            raise Exception("Computed HMAC does not match stored HMAC")
+        dec_ctr = Counter.new(128)
+        decryptor = AES.new(key, AES.MODE_CTR, counter=dec_ctr)
+        plaintext = decryptor.decrypt(b64decode(value.cyphertext)).decode("utf-8")
+        return plaintext

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "flywheel>=0.5.0",
         "microcosm>=0.11.0",
         "microcosm-logging>-0.9.3",
+        "PyCrypto>=2.6.1",
     ],
     setup_requires=[
         "nose>=1.3.7",


### PR DESCRIPTION
This adds an encrypted version of the dynamo db config loader, borrowing code from Credstash.

There are two obvious pitfalls here:

 1. There's enough overlap with Credstash, we should consider just using their code instead of rolling our own. The only way to make that work would to be to use their DynamoDB schema instead of ours; that mostly works except that we want to query by both service name and configuration key. To my knowledge, that makes it hard to query for a single service's config. But maybe someone can see a way in [their source](https://github.com/fugue/credstash/blob/master/credstash.py)

 2. The API is now a little awkward because we have a polymorphic value type. I'm open to suggestions on improving it. For example:

```
loader.put(service, name, loader.encrypt(value))
```

would be nicer as

```
loader.put(service, name, value)
```

That's a pretty easy change, but at the expense of a little more code complexity. Anyone think this is not worthwhile?