### PR TITLE
Add a conditional loader that uses an environment variable to load versioned data

### DIFF
--- a/microcosm_dynamodb/loaders/conventions.py
+++ b/microcosm_dynamodb/loaders/conventions.py
@@ -1,0 +1,77 @@
+"""
+Load configuration according to conventions:
+
+ 1. Use a KMS key based on the environment name.
+
+    The key is expected to be an alias named <environment>-conf.
+
+ 2. Load versioned configuration based on the `MICROCOSM_CONFIG_VERSION` environment variable.
+
+    If present, only the given config version is used; otherwise, dynamodb db loading is skipped.
+
+ 3. Encode semantic versions using the credstash version string
+
+
+"""
+from os import environ
+
+from credstash import paddedInt
+
+from microcosm_dynamodb.loaders.encrypted import EncryptedDynamoDBLoader
+
+
+def load_from_dynamodb(environment):
+    """
+    Fluent shorthand for the whole brevity thing.
+
+    """
+    return VersionedEncryptedDynamoDBLoader(environment)
+
+
+def kms_key_name(environment):
+    return "alias/{}-config".format(environment)
+
+
+def compute_version_string(version, base=1000):
+    """
+    Compute the version string to use for a specific version.
+
+    Normalizes the version using credstash's integer padding.
+
+    Drops the patch version under the assumption that we wish to simply restart
+    existing services rather than update their initialization configuration to use
+    a new version definition. However, retains padding space for the patch version
+    for forwards-compatibility.
+
+    """
+    major, minor, patch = version.split(".", 2)
+    return paddedInt(base ** 3 * int(major) + base ** 2 * int(minor))
+
+
+class VersionedEncryptedDynamoDBLoader(EncryptedDynamoDBLoader):
+
+    def __init__(self, environment):
+        """
+        Construct using KMS key based on environment name.
+
+        """
+        super(VersionedEncryptedDynamoDBLoader, self).__init__(
+            kms_key=kms_key_name(environment),
+            prefix=environment,
+        )
+
+    def __call__(self, metadata):
+        """
+        Conditionally load configuration based on the MICROCOSM_SERVICE_VERSION environment variable.
+
+        """
+        version = environ.get("MICROCOSM_CONFIG_VERSION")
+
+        if version is None:
+            # skip dynamodb loading; useful when AWS is not accessible
+            return {}
+
+        return super(VersionedEncryptedDynamoDBLoader, self).__call__(
+            metadata,
+            version=compute_version_string(version),
+        )

--- a/microcosm_dynamodb/loaders/conventions.py
+++ b/microcosm_dynamodb/loaders/conventions.py
@@ -5,7 +5,8 @@ Load configuration according to conventions:
 
     The key is expected to be an alias named <environment>-conf.
 
- 2. Load versioned configuration based on the `MICROCOSM_CONFIG_VERSION` environment variable.
+ 2. Load versioned configuration based on the `MICROCOSM_CONFIG_VERSION` and
+    `MICROCOSM_ENVIRONMENT` environment variables.
 
     If present, only the given config version is used; otherwise, dynamodb db loading is skipped.
 
@@ -16,15 +17,23 @@ Load configuration according to conventions:
 from os import environ
 
 from credstash import paddedInt
+from microcosm.loaders import load_from_dict
 
 from microcosm_dynamodb.loaders.encrypted import EncryptedDynamoDBLoader
 
 
-def load_from_dynamodb(environment):
+def load_from_dynamodb(environment=None):
     """
     Fluent shorthand for the whole brevity thing.
 
     """
+    if environment is None:
+        try:
+            environment = environ["MICROCOSM_ENVIRONMENT"]
+        except KeyError:
+            # noop
+            return load_from_dict(dict())
+
     return VersionedEncryptedDynamoDBLoader(environment)
 
 


### PR DESCRIPTION
With this PR, we can add `load_from_dynamodb()` to our loader chain and configuration should "do the right thing" if we define the right environment variables.

Specifically:
 - It wraps the dynamodb encrypted loader in a version aware loader.
 - It will not load anything if the version is not defined
 - It will only load a specific version of data otherwise.
 - Table names and KMS key names are by convention.

Still to do:
 - Figure out permissions so the whole team can use this code
 - Instrument all services
 - Update all config