### PR TITLE
Changed separator for key names of flattened dict store of configuration

### DIFF
--- a/microcosm_dynamodb/loaders/base.py
+++ b/microcosm_dynamodb/loaders/base.py
@@ -34,7 +34,7 @@ class DynamoDBLoader(object):
 
     def __init__(self,
                  prefix=None,
-                 separator=".",
+                 separator="__",
                  profile_name=None,
                  region=None):
         """

--- a/microcosm_dynamodb/tests/loaders/test_loader.py
+++ b/microcosm_dynamodb/tests/loaders/test_loader.py
@@ -26,7 +26,7 @@ SIMPLE_ITEM = dict(
 
 
 NESTED_ITEM = dict(
-    name="bar.baz",
+    name="bar__baz",
     dummy="foo",
     version="0000000000000000001",
 )


### PR DESCRIPTION
This corresponds with the `credstash_config` action plugin changes in Ansible.

We ran into issue with using `.`, so we're following our convention from environment variables: `__`.