### PR TITLE
Rely on Credstash cryptography

### DIFF
--- a/microcosm_dynamodb/loaders/encrypted.py
+++ b/microcosm_dynamodb/loaders/encrypted.py
@@ -11,10 +11,7 @@ from base64 import b64decode, b64encode
 from collections import namedtuple
 
 from boto3 import Session
-from Crypto.Cipher import AES
-from Crypto.Hash import SHA256
-from Crypto.Hash.HMAC import HMAC
-from Crypto.Util import Counter
+from credstash import KeyService, open_aes_ctr_legacy, seal_aes_ctr_legacy
 
 from microcosm_dynamodb.loaders.base import DynamoDBLoader
 
@@ -57,52 +54,30 @@ class EncryptedDynamoDBLoader(DynamoDBLoader):
     def decrypt(self, value, context=None):
         if not context:
             context = {}
-
         session = Session(profile_name=self.profile_name)
         kms = session.client('kms', region_name=self.region)
-
-        # Check the HMAC before we decrypt to verify ciphertext integrity
-        kms_response = kms.decrypt(
-            CiphertextBlob=b64decode(value.key),
-            EncryptionContext=context,
+        key_service = KeyService(kms, None, context)
+        return open_aes_ctr_legacy(
+            key_service,
+            dict(
+                key=value.key,
+                contents=value.contents,
+                hmac=value.hmac,
+            )
         )
-        key = kms_response['Plaintext'][:32]
-        hmac_key = kms_response['Plaintext'][32:]
-        hmac = HMAC(
-            hmac_key,
-            msg=b64decode(value.contents),
-            digestmod=SHA256,
-        )
-        if hmac.hexdigest() != value.hmac:
-            raise Exception("Computed HMAC does not match stored HMAC")
-        dec_ctr = Counter.new(128)
-        decryptor = AES.new(key, AES.MODE_CTR, counter=dec_ctr)
-        plaintext = decryptor.decrypt(b64decode(value.contents)).decode("utf-8")
-        return plaintext
 
     def encrypt(self, plaintext, context=None):
         if not context:
             context = {}
-
         session = Session(profile_name=self.profile_name)
         kms = session.client('kms', region_name=self.region)
-        kms_response = kms.generate_data_key(
-            KeyId=self.kms_key,
-            EncryptionContext=context,
-            NumberOfBytes=64,
+        key_service = KeyService(kms, None, context)
+        sealed = seal_aes_ctr_legacy(
+            key_service,
+            plaintext,
         )
-        data_key = kms_response['Plaintext'][:32]
-        hmac_key = kms_response['Plaintext'][32:]
-        wrapped_key = kms_response['CiphertextBlob']
-        enc_ctr = Counter.new(128)
-        encryptor = AES.new(data_key, AES.MODE_CTR, counter=enc_ctr)
-        c_text = encryptor.encrypt(plaintext)
-        # compute an HMAC using the hmac key and the ciphertext
-        hmac = HMAC(hmac_key, msg=c_text, digestmod=SHA256)
-        b64hmac = hmac.hexdigest()
-
         return EncryptedValue(
-            b64encode(wrapped_key).decode('utf-8'),
-            b64encode(c_text).decode('utf-8'),
-            b64hmac,
+            sealed["key"],
+            sealed["contents"],
+            sealed["hmac"],
         )

--- a/microcosm_dynamodb/loaders/encrypted.py
+++ b/microcosm_dynamodb/loaders/encrypted.py
@@ -7,7 +7,6 @@ but currently prevented from full reuse because of difficulty configurating cred
 See: https://github.com/fugue/credstash/blob/master/credstash.py
 
 """
-from base64 import b64decode, b64encode
 from collections import namedtuple
 
 from boto3 import Session

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "boto3>=1.4.0",
-        "credstash>=1.11.0",
-        # XXX credstash changed to depend on cryptography, not PyCrypto; we haven't migrated yet
-        "pycrypto>=2.6.1",
+        "credstash>=1.13.1",
         "flywheel>=0.5.0",
         "microcosm>=0.12.0",
         "microcosm-logging>-0.9.3",


### PR DESCRIPTION
Deprecated our own implementation of encrypt/decrypt in favor of accessing Credstash functions directly.
Retained our existing DynamoDB interaction logic.