### PR TITLE
Pass kms_key as part of KeyService call

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.14.2
+current_version = 0.14.3
 commit = False
 tag = False
 

--- a/microcosm_dynamodb/loaders/encrypted.py
+++ b/microcosm_dynamodb/loaders/encrypted.py
@@ -55,7 +55,7 @@ class EncryptedDynamoDBLoader(DynamoDBLoader):
             context = {}
         session = Session(profile_name=self.profile_name)
         kms = session.client('kms', region_name=self.region)
-        key_service = KeyService(kms, None, context)
+        key_service = KeyService(kms, self.kms_key, context)
         return open_aes_ctr_legacy(
             key_service,
             dict(
@@ -70,7 +70,7 @@ class EncryptedDynamoDBLoader(DynamoDBLoader):
             context = {}
         session = Session(profile_name=self.profile_name)
         kms = session.client('kms', region_name=self.region)
-        key_service = KeyService(kms, None, context)
+        key_service = KeyService(kms, self.kms_key, context)
         sealed = seal_aes_ctr_legacy(
             key_service,
             plaintext,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-dynamodb"
-version = "0.14.2"
+version = "0.14.3"
 
 setup(
     name=project,


### PR DESCRIPTION
Replaced behavior of passing `None` in the `encrypt` and `decrypt`
functions.