### PR TITLE
DynamoDBLoader should return a Config object

### DIFF
--- a/microcosm_dynamodb/loaders/base.py
+++ b/microcosm_dynamodb/loaders/base.py
@@ -12,6 +12,7 @@ from boto3 import Session
 from boto3.dynamodb.conditions import Attr
 from credstash import paddedInt
 
+from microcosm.configuration import Configuration
 from microcosm.loaders import expand_config
 
 
@@ -53,9 +54,11 @@ class DynamoDBLoader(object):
 
         """
         service = metadata if isinstance(metadata, string_types) else metadata.name
-        return expand_config(
-            dict(self.items(service, version=version)),
-            separator=self.separator,
+        return Configuration(
+            dct=expand_config(
+                dict(self.items(service, version=version)),
+                separator=self.separator,
+            ),
         )
 
     @abstractproperty


### PR DESCRIPTION
`expand_config` returns a dict, and it should then be made into a proper `Config` object.

The other option would have been to make `expand_config` to return a `Config` object, but this would have implications elsewhere - and more importantly the method's docstring  only states that is "Expands a dictionary recursively", so returning a `dict` makes more sense.

Because of the way `microcosm` does config merges, this bug had no consequence unless `load_from_dynamodb()` was the first loader in the config.